### PR TITLE
fix a problem with the selector

### DIFF
--- a/dist/framework7.angular.hook.js
+++ b/dist/framework7.angular.hook.js
@@ -21,7 +21,7 @@ Framework7.prototype.plugins.angular = function (app, params) {
     var $oldPage = $(".views .view .pages .page").not($(pageData.container));
     if ($oldPage.length > 0) {
       var controllerName = $oldPage.attr("ng-controller");
-      var $scope = angular.element('[ng-controller=' + controllerName + ']').scope();
+      var $scope = angular.element('[ng-controller="' + controllerName + '"]').scope();
       if ($scope) {
         $scope.$destroy();
         $oldPage.remove();


### PR DESCRIPTION
Indeed, [ngController](https://docs.angularjs.org/api/ng/directive/ngController) directive value can be an expression (so, not only a single 'word' that represents the controller name), for example: to publish the controller instance into a scope property using the `as` keyword.

Here is a simple PR that fixes this by enclosing the expression into double quotes :)